### PR TITLE
Ensure lspci(1) is installed before running Puppet

### DIFF
--- a/plans/commission.pp
+++ b/plans/commission.pp
@@ -1,4 +1,7 @@
 plan commission::commission(TargetSpec $nodes, Optional[String] $custom_facts, Optional[String] $puppet_settings) {
+  # lspci is needed by facter to determine if a node is physical or virutal
+  run_task('package', $nodes, 'install lspci', '_run_as' => 'root', 'action' => 'install', 'name' => 'pciutils')
+
   upload_file('commission/motd.commissioned', '/etc/motd', $nodes, '_run_as' => 'root')
 
   run_task('puppet_agent::install', $nodes, '_run_as' => 'root')


### PR DESCRIPTION
Facter rely on lspci(1) to check if the system is a physical or a
virtual one.  When lspci(1) is not found, facter thinks the node is a
physical one, which has an incidence on provisionning (e.g. ensuring
ntp(8) is installed, configured and running which makes basically no
sense on a virtual machine).