### PR TITLE
Make commission plan site specific

### DIFF
--- a/plans/commission.pp
+++ b/plans/commission.pp
@@ -1,27 +1,40 @@
 # Commission a node and connect it to the Puppet infrastructure
 #
 # @param nodes The nodes to commission
-# @param custom_facts Custom facts to set on comissioned nodes
-# @param puppet_settings Puppet settings to configure on comissioned nodes
+# @param puppetserver The Puppet Server that manage the nodes
+# @param customer The customer the nodes belongs to
+# @param provider The provider of the nodes
+# @param city The city where the nodes are located in
+# @param country The country the nodes are located in
 plan commission::commission(
-  TargetSpec $nodes,
-  Hash[String[1], Any] $custom_facts = {},
-  Hash[String[1], Any] $puppet_settings = {},
+  TargetSpec          $nodes,
+  String[1]           $puppetserver = 'puppet',
+  Optional[String[1]] $customer = undef,
+  Optional[String[1]] $provider = undef,
+  Optional[String[1]] $city     = undef,
+  Optional[String[1]] $country  = undef,
 ) {
   $commission_timestamp = Timestamp()
 
-  upload_file('commission/motd.commissioned', '/etc/motd', $nodes, '_run_as' => 'root')
+  $custom_facts = {
+    customer => $customer.lest || { prompt('Customer') },
+    provider => $provider.lest || { prompt('Provider') },
+    city     => $city.lest || { prompt('City') },
+    country  => $country.lest || { prompt('County') },
+  }
 
+  $puppet_settings = {
+    server => $puppetserver,
+    splay  => true,
+  }
+
+  upload_file('commission/motd.commissioned', '/etc/motd', $nodes, '_run_as' => 'root')
   # lspci is needed by facter to determine if a node is physical or virutal
   run_task('package', $nodes, 'install lspci', '_run_as' => 'root', 'action' => 'install', 'name' => 'pciutils')
-
   run_task('puppet_agent::install', $nodes, '_run_as' => 'root')
 
   run_task('commission::add_custom_facts', $nodes, '_run_as' => 'root', 'facts' => $custom_facts)
-
   run_task('commission::set_puppet_config', $nodes, '_run_as' => 'root', 'settings' => $puppet_settings)
-
-  run_command('/opt/puppetlabs/bin/puppet agent --test', $nodes, '_run_as' => 'root', '_catch_errors' => true)
 
   $certificate_requests = Hash(run_task('commission::get_certificate_request', $nodes, '_run_as' => 'root').map |$result| {
       # Extract the cername from the ssh connexion string that can be in the form [user@]certname[:port]
@@ -29,10 +42,8 @@ plan commission::commission(
 
       Array([$certname, $result.value])
   })
-
-  run_task('commission::sign_certificate_requests', 'puppet', '_run_as' => 'root', certificate_requests => $certificate_requests)
+  run_task('commission::sign_certificate_requests', $puppetserver, '_run_as' => 'root', certificate_requests => $certificate_requests)
 
   run_task('service', $nodes, 'Starting puppet', '_run_as' => 'root', 'action' => 'start', 'name' => 'puppet')
-
-  run_task('commission::add_custom_facts', $nodes, '_run_as' => 'root', 'facts' => { 'comissioned_at' => $commission_timestamp })
+  run_task('commission::add_custom_facts', $nodes, '_run_as' => 'root', 'facts' => { 'comissioned_at' => Timestamp() })
 }

--- a/plans/decommission.pp
+++ b/plans/decommission.pp
@@ -1,7 +1,9 @@
 # Decommission a node and disconnect it from the Puppet infrastructure
 #
 # @param nodes The nodes to decommission
-plan commission::decommission(TargetSpec $nodes) {
+plan commission::decommission(TargetSpec $nodes, String[1] $puppetserver = undef) {
+  $puppetserver_node = $puppetserver.lest || { prompt('puppetserver') }
+
   upload_file('commission/motd.decommissioned', '/etc/motd', $nodes, '_run_as' => 'root')
 
   run_task('service', $nodes, 'Stopping puppet', '_run_as' => 'root', 'action' => 'stop', 'name' => 'puppet')
@@ -15,8 +17,8 @@ plan commission::decommission(TargetSpec $nodes) {
   run_script('commission/clean-cron-jobs.sh', $nodes, '_run_as' => 'root')
 
   get_targets($nodes).each |$node| {
-    run_command("/opt/puppetlabs/bin/puppetserver ca revoke --certname ${node.name}", 'puppet', '_run_as' => 'root')
-    run_command("/opt/puppetlabs/bin/puppet node deactivate ${node.name}", 'puppet', '_run_as' => 'root')
+    run_command("/opt/puppetlabs/bin/puppetserver ca revoke --certname ${node.name}", $puppetserver_node, '_run_as' => 'root')
+    run_command("/opt/puppetlabs/bin/puppet node deactivate ${node.name}", $puppetserver_node, '_run_as' => 'root')
   }
 
   run_task('package', $nodes, 'Uninstalling puppet-agent', '_run_as' => 'root', 'action' => 'uninstall', 'name' => 'puppet-agent')


### PR DESCRIPTION
Commissioning should be site dependent.

Make the commissioning script even site agnostic (no requirement for a `puppet` node, prompt for this node) and add instructions to the README to tell people how to make a commissioning script for their site that math their needs.

Same for decommissioning.

Blocked on:
* #14 
* #15 
* #16 