### PR TITLE
Set puppet settings from a task instead of a script

### DIFF
--- a/files/setup-puppet-agent.sh
+++ b/files/setup-puppet-agent.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-IFS=,
-set -- $*
-for setting; do
-	k=${setting%=*}
-	v=${setting#*=}
-	/opt/puppetlabs/bin/puppet config set "$k" "$v"
-done

--- a/plans/commission.pp
+++ b/plans/commission.pp
@@ -3,7 +3,11 @@
 # @param nodes The nodes to commission
 # @param custom_facts Custom facts to set on comissioned nodes
 # @param puppet_settings Puppet settings to configure on comissioned nodes
-plan commission::commission(TargetSpec $nodes, Hash[String[1],Any] $custom_facts = {}, Optional[String] $puppet_settings) {
+plan commission::commission(
+  TargetSpec $nodes,
+  Hash[String[1], Any] $custom_facts = {},
+  Hash[String[1], Any] $puppet_settings = {},
+) {
   $commission_timestamp = Timestamp()
 
   upload_file('commission/motd.commissioned', '/etc/motd', $nodes, '_run_as' => 'root')
@@ -15,9 +19,7 @@ plan commission::commission(TargetSpec $nodes, Hash[String[1],Any] $custom_facts
 
   run_task('commission::add_custom_facts', $nodes, '_run_as' => 'root', 'facts' => $custom_facts)
 
-  if $puppet_settings {
-    run_script('commission/setup-puppet-agent.sh', $nodes, '_run_as' => 'root', 'arguments' => [$puppet_settings])
-  }
+  run_task('commission::set_puppet_config', $nodes, '_run_as' => 'root', 'settings' => $puppet_settings)
 
   run_command('/opt/puppetlabs/bin/puppet agent --test', $nodes, '_run_as' => 'root', '_catch_errors' => true)
 

--- a/tasks/set_puppet_config.json
+++ b/tasks/set_puppet_config.json
@@ -1,0 +1,11 @@
+{
+  "description": "Set Puppet configuration",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "settings": {
+      "description": "The settings to set",
+      "type": "Hash[String[1],Any]"
+    }
+  }
+}

--- a/tasks/set_puppet_config.rb
+++ b/tasks/set_puppet_config.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'open3'
+
+require_relative '../../ruby_task_helper/files/task_helper'
+
+class SetPuppetConfig < TaskHelper
+  def task(settings:, **_kwargs)
+    # Prepend AIO path if it exist and is not in $PATH
+    if File.directory?('/opt/puppetlabs/puppet/bin') &&
+       !ENV['PATH'].split(':').include?('/opt/puppetlabs/puppet/bin')
+      ENV['PATH'] = "/opt/puppetlabs/puppet/bin:#{ENV['PATH']}"
+    end
+
+    settings.each do |setting_name, setting_value|
+      Open3.capture3('puppet', 'config', 'set', setting_name.to_s, setting_value.to_s)
+    end
+
+    nil
+  end
+end
+
+SetPuppetConfig.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
This allows us to pass settings as a complex data structure the way we
do it with facts for better validation.