### PR TITLE
Ensure Puppet AIO path

### DIFF
--- a/tasks/sign_certificate_requests.rb
+++ b/tasks/sign_certificate_requests.rb
@@ -5,6 +5,12 @@ require_relative '../../ruby_task_helper/files/task_helper'
 
 class SignCertificateRequests < TaskHelper
   def task(certificate_requests:, **_kwargs)
+    # Prepend AIO path if it exist and is not in $PATH
+    if File.directory?('/opt/puppetlabs/puppet/bin') &&
+       !ENV['PATH'].split(':').include?('/opt/puppetlabs/puppet/bin')
+      ENV['PATH'] = "/opt/puppetlabs/puppet/bin:#{ENV['PATH']}"
+    end
+
     certificate_requests.each do |node, details|
       if pending_requests[node] == details
         system('puppetserver', 'ca', 'sign', node)


### PR DESCRIPTION
When signing certificates on AIO Puppet, ensure the right directory is
in the path before attempting to sign.
