### PR TITLE
Hide template plans by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installing project modules
 
 Successfully synced modules from ~/acme/Puppetfile to ~/acme/.modules
 romain@marvin ~/acme % mkdir -p plans
-romain@marvin ~/acme % sed -e 's/commission::commission/acme::commission/' < .modules/commission/plans/commission.pp > plans/commission.pp
+romain@marvin ~/acme % sed -e 's/commission::commission/acme::commission/' -e '/@api private/,+1d' < .modules/commission/plans/commission.pp > plans/commission.pp
 romain@marvin ~/acme % bolt plan show
 Plans
   acme::commission       Commission a node and connect it to the Puppet infrastructure

--- a/plans/commission.pp
+++ b/plans/commission.pp
@@ -1,4 +1,6 @@
-# Commission a node and connect it to the Puppet infrastructure
+# Commission nodes and connect them to the Puppet infrastructure
+#
+# @api private
 #
 # @param nodes The nodes to commission
 # @param puppetserver The Puppet Server that manage the nodes

--- a/plans/decommission.pp
+++ b/plans/decommission.pp
@@ -1,6 +1,9 @@
-# Decommission a node and disconnect it from the Puppet infrastructure
+# Decommission nodes and disconnect them from the Puppet infrastructure
+#
+# @api private
 #
 # @param nodes The nodes to decommission
+# @param puppetserver The Puppet Server that manage the nodes
 plan commission::decommission(
   TargetSpec $nodes,
   Optional[String[1]] $puppetserver = undef,


### PR DESCRIPTION
When we use the module in an acme organization, we do not want to see the template plans:

```
Plans
  commission::commission          Commission nodes and connect them to the Puppet infrastructure
  commission::decommission        Decommission nodes and disconnect them from the Puppet infrastructure
```

We only want to see the actual plans created by following the README instructions:

```
Plans
  acme::commission                Commission nodes and connect them to the ACME infrastructure
  acme::decommission              Decommission nodes and disconnect them from the ACME infrastructure
```
