### PR TITLE
Improve error reporting

### DIFF
--- a/tasks/deactivate_nodes.rb
+++ b/tasks/deactivate_nodes.rb
@@ -11,7 +11,7 @@ class DeactivateNodes < TaskHelper
       ENV['PATH'] = "/opt/puppetlabs/puppet/bin:#{ENV['PATH']}"
     end
 
-    system('puppet', 'node', 'deactivate', *nodes) || raise(TaskHelper::Error.new('Failed to deactivate nodes', 'deactivate_nodes', 'puppet exited with a non-null error code'))
+    system('puppet', 'node', 'deactivate', *nodes) || raise(TaskHelper::Error.new('Failed to deactivate nodes', 'deactivate_nodes'))
 
     nil
   end

--- a/tasks/get_certificate_request.rb
+++ b/tasks/get_certificate_request.rb
@@ -14,9 +14,11 @@ class GetCertificateRequest < TaskHelper
       ENV['PATH'] = "/opt/puppetlabs/puppet/bin:#{ENV['PATH']}"
     end
 
-    `puppet ssl bootstrap --waitforcert 0`
+    bootrap_output = `puppet ssl bootstrap --color false --waitforcert 0 2>&1`
 
-    `puppet agent --fingerprint` =~ /\A\(([^)]+)\)\s+([[:xdigit:]:]+)/
+    fingerprint_output = `puppet agent --color false --fingerprint 2>&1`
+    fingerprint_output =~ /\A\(([^)]+)\)\s+([[:xdigit:]:]+)/
+    raise(TaskHelper::Error.new("Failed to get certificate request\n===> `puppet ssl bootstrap --waitforcert 0` output:\n#{bootrap_output}\n===> `puppet agent --fingerprint` output:\n#{fingerprint_output}", 'get_certificate_request')) if Regexp.last_match.nil?
 
     {
       digest: Regexp.last_match(1),

--- a/tasks/set_puppet_config.rb
+++ b/tasks/set_puppet_config.rb
@@ -12,7 +12,7 @@ class SetPuppetConfig < TaskHelper
     end
 
     settings.each do |setting_name, setting_value|
-      system('puppet', 'config', 'set', setting_name.to_s, setting_value.to_s) || raise(TaskHelper::Error.new('Failed to set setting', 'set_puppet_config', 'puppet exited with a non-null error code'))
+      system('puppet', 'config', 'set', setting_name.to_s, setting_value.to_s) || raise(TaskHelper::Error.new('Failed to set setting', 'set_puppet_config'))
     end
 
     nil

--- a/tasks/sign_certificate_requests.rb
+++ b/tasks/sign_certificate_requests.rb
@@ -13,11 +13,10 @@ class SignCertificateRequests < TaskHelper
 
     certificate_requests.each do |node, details|
       if pending_requests[node] == details
-        system('puppetserver', 'ca', 'sign', '--certname', node.to_s) || raise(TaskHelper::Error.new('Failed to sign certificate requests', 'sign_certificate_requests', 'puppetserver exited with a non-null error code'))
+        system('puppetserver', 'ca', 'sign', '--certname', node.to_s) || raise(TaskHelper::Error.new('Failed to sign certificate requests', 'sign_certificate_requests'))
       else
-        raise TaskHelper::Error.new('Certificate Request not fournd',
-                                    'sign_agent_certificate/certificate_request_not_found',
-                                    "No certificate request for #{node} with digest #{details[:digest]} and fingerprint #{details[:fingerprint]}")
+        raise TaskHelper::Error.new("No certificate request was fournd for #{node} with digest #{details[:digest]} and fingerprint #{details[:fingerprint]}",
+                                    'sign_agent_certificate/certificate_request_not_found')
       end
     end
 


### PR DESCRIPTION
If collecting information about a certificate request fail for some reason, we do not want to return invalid data, but detect it and raise an error.  This happen e.g. when a node is reprovisioned after being decomissioned and the revoked certificate was not cleaned from the Puppet Server.

While here, also improve some raised exceptions.