### PR TITLE
Fix AIO path for PuppetServer

### DIFF
--- a/tasks/sign_certificate_requests.rb
+++ b/tasks/sign_certificate_requests.rb
@@ -13,7 +13,7 @@ class SignCertificateRequests < TaskHelper
 
     certificate_requests.each do |node, details|
       if pending_requests[node] != details
-        raise TaskHelper::Error.new("No certificate request was fournd for #{node} with digest #{details[:digest]} and fingerprint #{details[:fingerprint]}",
+        raise TaskHelper::Error.new("No certificate request was found for #{node} with digest #{details[:digest]} and fingerprint #{details[:fingerprint]}",
                                     'sign_agent_certificate/certificate_request_not_found')
       end
 

--- a/tasks/sign_certificate_requests.rb
+++ b/tasks/sign_certificate_requests.rb
@@ -6,9 +6,9 @@ require_relative '../../ruby_task_helper/files/task_helper'
 class SignCertificateRequests < TaskHelper
   def task(certificate_requests:, **_kwargs)
     # Prepend AIO path if it exist and is not in $PATH
-    if File.directory?('/opt/puppetlabs/puppet/bin') &&
-       !ENV.fetch('PATH').split(':').include?('/opt/puppetlabs/puppet/bin')
-      ENV['PATH'] = "/opt/puppetlabs/puppet/bin:#{ENV.fetch('PATH')}"
+    if File.directory?('/opt/puppetlabs/bin') &&
+       !ENV.fetch('PATH').split(':').include?('/opt/puppetlabs/bin')
+      ENV['PATH'] = "/opt/puppetlabs/bin:#{ENV.fetch('PATH')}"
     end
 
     certificate_requests.each do |node, details|


### PR DESCRIPTION
The AIO Puppet Server is installed in `/opt/puppetlabs/server`, `/opt/puppetlabs/puppet` being the path of the Agent.

Both Agent and Server binaries have symlinks in `/opt/puppetlabs/bin`, it is this directory that we want to make sure is part of $PATH before running `puppetserver ca list` and `puppetserver ca sign`.
